### PR TITLE
Swap diffusion denoiser to cNCSNpp backbone

### DIFF
--- a/scripts/configs/configs/defaults.py
+++ b/scripts/configs/configs/defaults.py
@@ -20,6 +20,7 @@ def get_default_configs():
     config.training.batch_size = 16  # 128
     
     training.n_epochs = 100
+    training.continuous = True
     # Buffer around the output fields when calculating the loss. 
     # Experimental option to mitigate against boundary effects;
     # didn't improve performance
@@ -81,6 +82,19 @@ def get_default_configs():
     # Fourier best suited for our setup, but can be positional or
     model.embedding_type = "fourier"
     model.diffusion = True
+    model.resblock_type = "biggan"
+    model.progressive = "output_skip"
+    model.progressive_input = "input_skip"
+    model.progressive_combine = "sum"
+    model.fir = False
+    model.fir_kernel = [1, 3, 3, 1]
+    model.skip_rescale = True
+    model.init_scale = 0.0
+    model.scale_by_sigma = False
+    model.sigma_min = 0.01
+    model.sigma_max = 50.0
+    model.num_scales = 1000
+    model.loc_spec_channels = 0
 
     # Generic optimisation parameters - these are all relatively safe choices
     config.optim = optim = ml_collections.ConfigDict()

--- a/src/diffusion_downscaling/lightning/models/utils.py
+++ b/src/diffusion_downscaling/lightning/models/utils.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+"""Utility helpers for score-based models."""
+from __future__ import annotations
+
+import math
+from typing import Callable, Dict
+
+import numpy as np
+
+MODEL_REGISTRY: Dict[str, Callable] = {}
+
+
+def register_model(name: str):
+    """Decorator to register a model class by name."""
+    def decorator(cls):
+        MODEL_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_sigmas(config):
+    """Return a sigma schedule used for positional embeddings."""
+    sigma_min = getattr(config.model, "sigma_min", 0.01)
+    sigma_max = getattr(config.model, "sigma_max", 50.0)
+    num_scales = getattr(config.model, "num_scales", 1000)
+
+    sigma_min = max(float(sigma_min), 1e-6)
+    sigma_max = max(float(sigma_max), sigma_min)
+    num_scales = max(int(num_scales), 2)
+
+    return np.exp(np.linspace(math.log(sigma_max), math.log(sigma_min), num_scales))

--- a/src/diffusion_downscaling/lightning/utils.py
+++ b/src/diffusion_downscaling/lightning/utils.py
@@ -28,6 +28,7 @@ from ..yang_cm.utils import create_model as create_cm_model
 from .models.diffusion import LightningDiffusion, setup_edm_model, setup_vp_model
 from .models.deterministic import LightningDeterministic
 from .models.gan import LightningGAN
+from .models.cncsnpp import cNCSNpp
 
 load_dotenv()
 
@@ -57,7 +58,7 @@ def build_model(config, checkpoint_name=None):
     }
 
     if model_type == "diffusion":
-        base_model = create_cm_model(config)
+        base_model = cNCSNpp(config)
 
         diffusion_type = config.diffusion_type
 


### PR DESCRIPTION
### Motivation
- Replace the UNet/yang_cm-based backbone with the cNCSNpp score network so the diffusion denoiser uses the cNCSNpp architecture for both training and sampling while keeping the sampling procedure unchanged.
- Make the cNCSNpp integration robust against different config styles and ensure the required sigma schedule and model defaults are present.

### Description
- Instantiate `cNCSNpp(config)` as the diffusion `base_model` in `build_model` instead of the previous `create_cm_model` UNet (changed in `src/diffusion_downscaling/lightning/utils.py`).
- Update `src/diffusion_downscaling/lightning/models/cncsnpp.py` to use local relative imports, add `_get_variable_counts(config)` to derive conditioning and output channel counts from multiple config formats, and wire `get_sigmas` via the new helper.
- Add `src/diffusion_downscaling/lightning/models/utils.py` providing `register_model` and `get_sigmas` (sigma schedule generator) to support cNCSNpp embeddings and registration.
- Extend default model configuration in `scripts/configs/configs/defaults.py` with cNCSNpp-relevant settings (e.g. `continuous`, `resblock_type`, `progressive*`, `sigma_min`, `sigma_max`, `num_scales`, and other flags) so configs are compatible out-of-the-box.

### Testing
- No automated tests were executed as part of this change (no CI/test runner invoked).
- Recommend running the standard training and sampling workflows (e.g. the existing training script and `scripts/inference.py` sampling) to validate end-to-end training and sampling correctness with `cNCSNpp` as the denoiser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983472e72488324a7405e2100435308)