### PR TITLE
fix: save all epoch checkpoints instead of only top 10

### DIFF
--- a/src/diffusion_downscaling/lightning/utils.py
+++ b/src/diffusion_downscaling/lightning/utils.py
@@ -264,7 +264,7 @@ def get_callbacks(callback_args):
             dirpath=checkpoint_dir,
             filename="{epoch}-{val_loss:.4f}",
             every_n_epochs=1,
-            save_top_k=10,
+            save_top_k=-1,
             monitor="val_loss",
             save_last=True,
         )


### PR DESCRIPTION
Changed ModelCheckpoint save_top_k from 10 to -1 so that every epoch checkpoint is retained. Previously only the 10 best checkpoints by val_loss were kept, silently deleting the rest during training.

Fixes #7