### PR TITLE
Use build_josh_datamodule directly for inference; remove build_dataloader

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -25,24 +25,11 @@ torch.set_float32_matmul_precision("medium")
 
 sys.path.append(os.getcwd())
 
-from src.diffusion_downscaling.lightning.utils import configure_location_args, build_or_load_data_scaler, build_model, setup_custom_training_coords
-from src.diffusion_downscaling.data.scaling import DataScaler
-#import diffusion_downscaling.lightning.utils as lightning_utils
-
+from src.diffusion_downscaling.lightning.utils import build_model
 from src.diffusion_downscaling.sampling.sampling import Sampler
-#from diffusion_downscaling.sampling.sampling import Sampler
-
 from src.diffusion_downscaling.evaluation.utils import build_evaluation_callable
-#from diffusion_downscaling.evaluation.utils import build_evaluation_callable
-
 from src.diffusion_downscaling.sampling.utils import create_sampling_configurations
-#from diffusion_downscaling.sampling.utils import create_sampling_configurations
-
-from src.diffusion_downscaling.data.constants import TRAINING_COORDS_LOOKUP
-#from diffusion_downscaling.data.constants import TRAINING_COORDS_LOOKUP
-
 from configs.metrics.basic_eval_metrics import EVAL_METRICS as eval_metrics
-#from configs.metrics.basic_eval_metrics import EVAL_METRICS as eval_metrics
 
 def parse_module(path):
     return path.replace(".py", "").replace("/", ".")
@@ -85,8 +72,6 @@ def run_eval(config, sampling_config, predictions_only=True):
     config.data.eval_indices = sampling_config.eval_indices
     output_variables = config.data.variables[1]
 
-    use_josh_pipeline = getattr(config.data, "use_josh_pipeline", True)
-
     data_path = Path(config.data.dataset_path) if config.data.dataset_path else None
     location_config = dict(sampling_config.eval).get("location_config")
     if not hasattr(config.model, "location_parameter_config"):
@@ -117,34 +102,18 @@ def run_eval(config, sampling_config, predictions_only=True):
     if custom_dset is not None:
         data_path = Path(custom_dset)
         config.data.dataset_path = str(data_path)
-        if use_josh_pipeline:
-            config.data.filename = str(data_path)
-            config.data.val_filename = str(data_path)
+        config.data.filename = str(data_path)
 
-    if use_josh_pipeline:
-        data_scaler = DataScaler({})
-    else:
-        if data_path is None:
-            data_path = Path(config.data.dataset_path)
-        config = configure_location_args(config, data_path)
-        data_scaler_path = sampling_config.get('data_scaler_path') or output_dir / 'scaler_parameters.pkl'
-        data_scaler = build_or_load_data_scaler(config, data_scaler_path)
-    
     model = build_model(config, checkpoint_name)
 
     config.training.batch_size = sampling_config.batch_size
-    config = setup_custom_training_coords(config, sampling_config)
 
     if predictions_only:
-        variables = (config.data.variables[0], [])
-        if not use_josh_pipeline:
-            data_scaler.set_transform_exclusion(config.data.variables[1])
-        config.data.variables = variables    
+        config.data.variables = (config.data.variables[0], [])
 
     evaluation_sampler = Sampler(
         model,
         config.model_type,
-        data_scaler,
         output_variables,
         sampling_config.output_format,
     )

--- a/src/diffusion_downscaling/lightning/utils.py
+++ b/src/diffusion_downscaling/lightning/utils.py
@@ -319,82 +319,16 @@ def get_callbacks(callback_args):
 #         return split
 
 
-def build_dataloaders(config, transform, num_workers):
+def build_josh_datamodule(config, num_workers=0, mode="train"):
+    """Build the Josh LightningDataModule.
 
-    if getattr(config.data, "use_josh_pipeline", True):
-        logger.info(" >> >> INSIDE lightning.utils build_dataloaders | use_josh_pipeline")
-        datamodule = build_josh_datamodule(config, num_workers=num_workers)
-        datamodule.setup("fit")
-        return datamodule.train_dataloader(), datamodule.val_dataloader()
-
-    logger.info(" >> >> INSIDE lightning.utils | PASSED BY if getattr use_josh_pipeline")
-    # dl_configs = [
-    #     (config.data.train_indices, True, False),
-    #     (config.data.eval_indices, False, True),
-    # ]
-    # dls = (
-    #     build_dataloader(
-    #         config.data.dataset_path,
-    #         config.data.variables,
-    #         indices,
-    #         transform,
-    #         config.data.variable_location,
-    #         config.data.location_config,
-    #         config.data.image_size,
-    #         config.training.loss_buffer_width,
-    #         config.data.training_coords,
-    #         config.training.batch_size,
-    #         shuffle=shuffle,
-    #         evaluation=evaluation,
-    #         num_workers=num_workers,
-    #     )
-    #     for indices, shuffle, evaluation in dl_configs
-    # )
-
-    # return dls
-
-
-# def build_dataloader(
-#     data_path,
-#     variables,
-#     indices,
-#     transform,
-#     variable_location,
-#     location_config,
-#     image_size,
-#     buffer_width,
-#     training_coords,
-#     batch_size,
-#     shuffle,
-#     evaluation,
-#     num_workers,
-# ):
-#     formatted_indices = create_indices(indices)
-#     dloader_kwargs = dict(        
-#         include_time_inputs=False,
-#         variable_location=variable_location,
-#         location_config=location_config,
-#         image_size=image_size,
-#         buffer_width=buffer_width,
-#         training_coords=training_coords,
-#         batch_size=batch_size,
-#         split=formatted_indices,
-#         evaluation=evaluation,
-#         shuffle=shuffle,
-#         num_workers=num_workers,
-#     )
-    
-#     dataloader = get_dataloader(
-#         data_path,
-#         variables,
-#         transform,
-#         **dloader_kwargs
-#     )
-#     return dataloader
-
-
-def build_josh_datamodule(config, num_workers=0):
+    :param config: Config object.
+    :param num_workers: int, number of DataLoader workers.
+    :param mode: str, either "train" (sets up train/val dataloaders) or "test"
+        (sets up test dataloader for inference). Affects shuffle and evaluation flags.
+    """
     data_cfg = config.data
+    is_test = mode == "test"
     return JoshDataModule(
         config=config,
         active_dataset_name=data_cfg.dataset,
@@ -407,8 +341,8 @@ def build_josh_datamodule(config, num_workers=0):
         filename=getattr(data_cfg, "filename", getattr(data_cfg, "train_filename", None)),
         val_filename=getattr(data_cfg, "val_filename", None),
         include_time_inputs=getattr(data_cfg, "time_inputs", False),
-        evaluation=False,
-        shuffle=True,
+        evaluation=is_test,
+        shuffle=not is_test,
         num_workers=num_workers,
         prefetch_factor=getattr(data_cfg, "prefetch_factor", None),
     )

--- a/src/diffusion_downscaling/sampling/sampling.py
+++ b/src/diffusion_downscaling/sampling/sampling.py
@@ -24,18 +24,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 from ..lightning import utils as lightning_utils
-from ..data.scaling import DataScaler
-from ..data.data_loading import  select_custom_coordinates
-
-
-def _open_dataset(path: Path):
-    path = Path(path)
-    if path.suffix == ".zarr" or path.is_dir():
-        try:
-            return xr.open_zarr(path, consolidated=True)
-        except (KeyError, ValueError, OSError):
-            return xr.open_zarr(path)
-    return xr.open_dataset(path)
 
 
 def make_predictions_filename(directory, config, prefix="predictions"):
@@ -125,7 +113,6 @@ class Sampler:
         self,
         model: nn.Module,
         model_type: str,
-        data_scaler: DataScaler,
         output_variables: List[str],
         output_string_format: str,
     ):
@@ -133,15 +120,12 @@ class Sampler:
 
         :param model: PyTorch model to sample from
         :param model_type: str, model type (diffusion, gan, deterministic)
-        :param data_scaler: DataScaler, data scaler to rescale the model outputs. Must have a transform
-            method that acts on a xarray object.
         :param output_variables: List[str], output variable names.
         :param output_string_format: str, formattable string that can include config-specific parameters
             to generate the name of the output directory.
         """
         self.model = model
         self.eval_dl = None
-        self.data_scaler = data_scaler
         self.output_variables = output_variables
         self.output_string_format = output_string_format
         self.model_specific_sampling = self.model_sampling_callables[model_type]
@@ -170,18 +154,18 @@ class Sampler:
         """
         self.precision = self.precision_lookup[main_config.precision]
 
-        xr_data = _open_dataset(main_config.data.dataset_path)
         buffer_width = main_config.training.loss_buffer_width
-
         sampling_args, all_configs = eval_args
 
         for config in all_configs:
             location_config = config[2]["location_config"]
-            coords = select_custom_coordinates(xr_data, location_config, buffer_width)
             main_config.data.location_config = location_config
-            _, self.eval_dl = lightning_utils.build_dataloaders(
-                main_config, self.data_scaler.transform, num_workers=1
+
+            datamodule = lightning_utils.build_josh_datamodule(
+                main_config, num_workers=1, mode="test"
             )
+            datamodule.setup("test")
+            self.eval_dl = datamodule.test_dataloader()
 
             output_string = self.format_output_dir_name(config)
             output_path, predictions_dir, results_dir = self.setup_output_dirs(
@@ -192,7 +176,7 @@ class Sampler:
             print(f"Beginning predictions on {output_string}", flush=True)
             self.generate_predictions(
                 config,
-                coords,
+                None,
                 num_samples,
                 predictions_dir,
                 sampling_args,
@@ -202,7 +186,7 @@ class Sampler:
 
             if evaluator is not None:
                 print(f"Beginning evaluation on {output_string}", flush=True)
-                evaluator(predictions_dir, results_dir, coords, buffer_width)
+                evaluator(predictions_dir, results_dir, None, buffer_width)
                 print(f"Finished evaluation on {output_string}", flush=True)
 
     def setup_output_dirs(self, base_output: str, output_string: str):
@@ -357,37 +341,24 @@ class Sampler:
         return preds_ds
 
     def rescale_outputs(self, preds: np.ndarray):
-        """Rescale outputs back to true data units using the data_scaler.
+        """Rescale outputs back to true data units using target transforms from the dataloader.
 
-        All predictions are done in scaled units; we rescale back to true
-        data units before saving them to file.
+        Target transforms are saved as pickle files during training and loaded by FastCollate.
+        This recovers actual precipitation (or other variable) values after sampling.
 
         :param preds: np.ndarray, model predictions.
         :return: Dict, rescaled outputs.
         """
         scaled_outputs = {}
         target_transforms = self._get_target_transforms()
-        if target_transforms:
-            for var_idx, variable in enumerate(self.output_variables):
-                transform = target_transforms.get(variable)
-                if transform is None:
-                    if hasattr(self.data_scaler, "variable_scaler_map") and (
-                        variable in self.data_scaler.variable_scaler_map
-                    ):
-                        scaled_outputs[variable] = self.data_scaler.variable_scaler_map[
-                            variable
-                        ].inverse_transform(preds[:, var_idx])
-                    else:
-                        scaled_outputs[variable] = preds[:, var_idx]
-                else:
-                    scaled_outputs[variable] = self._invert_with_transform(
-                        transform, variable, preds[:, var_idx]
-                    )
-            return scaled_outputs
         for var_idx, variable in enumerate(self.output_variables):
-            scaled_outputs[variable] = self.data_scaler.variable_scaler_map[
-                variable
-            ].inverse_transform(preds[:, var_idx])
+            transform = target_transforms.get(variable) if target_transforms else None
+            if transform is not None:
+                scaled_outputs[variable] = self._invert_with_transform(
+                    transform, variable, preds[:, var_idx]
+                )
+            else:
+                scaled_outputs[variable] = preds[:, var_idx]
         return scaled_outputs
 
     def format_output_dir_name(self, config):


### PR DESCRIPTION
Add mode=train/test flag to build_josh_datamodule: test mode sets evaluation=True and shuffle=False, training mode keeps existing defaults. Replace build_dataloaders call in sampling.py with build_josh_datamodule (mode=test) + setup(test) + test_dataloader() directly. Remove DataScaler and select_custom_coordinates imports, _open_dataset helper, and data_scaler from Sampler.__init__ in sampling.py. Simplify rescale_outputs to use only FastCollate target_transforms. Remove broken imports, use_josh_pipeline branching, and data_scaler creation from inference.py.
Remove build_dataloaders from lightning/utils.py as it is now dead code.