### PR TITLE
fix: remove @torch.compile from AbstractKarrasDenoiser methods

### DIFF
--- a/src/diffusion_downscaling/lightning/models/karras_diffusion.py
+++ b/src/diffusion_downscaling/lightning/models/karras_diffusion.py
@@ -48,7 +48,6 @@ class AbstractKarrasDenoiser(nn.Module):
         """
         return self.sigma_data**2 / (sigma**2 + self.sigma_data**2)
 
-    @torch.compile
     def loss(self, input, condition, **kwargs):
         """Key function for training EDM-type diffusion models.
 
@@ -81,7 +80,6 @@ class AbstractKarrasDenoiser(nn.Module):
         )
         return (img_flattened * c_weight.unsqueeze(1)).mean(dim=0)
 
-    @torch.compile
     def forward(self, input, cond, sigma, **kwargs):
         c_skip, c_out, c_in = [
             append_dims(x, input.ndim) for x in self.get_scalings(sigma)


### PR DESCRIPTION
Removes @torch.compile decorators from AbstractKarrasDenoiser.loss() and AbstractKarrasDenoiser.forward() in karras_diffusion.py.

The method-level decorators broke Python's descriptor protocol, causing self not to be bound when combined with the two existing module-level torch.compile calls (in setup_edm_model and build_model). The resulting triple-compilation caused inference to fail with TypeError: AbstractKarrasDenoiser.forward() missing 1 required positional argument: 'sigma'.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)